### PR TITLE
Add `completely install` command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,3 +18,8 @@ AllCops:
 Naming/AccessorMethodName:
   Exclude:
     - 'lib/completely/tester.rb'
+
+# The `bounce` method here is more readable without this cop
+Style/GuardClause:
+  Exclude:
+    - 'lib/completely/commands/install.rb'

--- a/lib/completely/cli.rb
+++ b/lib/completely/cli.rb
@@ -1,9 +1,10 @@
 require 'mister_bin'
-require 'completely/commands/init'
-require 'completely/commands/preview'
-require 'completely/commands/generate'
-require 'completely/commands/test'
 require 'completely/version'
+require 'completely/commands/generate'
+require 'completely/commands/init'
+require 'completely/commands/install'
+require 'completely/commands/preview'
+require 'completely/commands/test'
 
 module Completely
   class CLI
@@ -16,6 +17,7 @@ module Completely
       runner.route 'preview',   to: Commands::Preview
       runner.route 'generate',  to: Commands::Generate
       runner.route 'test',      to: Commands::Test
+      runner.route 'install',   to: Commands::Install
 
       runner
     end

--- a/lib/completely/commands/install.rb
+++ b/lib/completely/commands/install.rb
@@ -3,7 +3,21 @@ require 'completely/commands/base'
 module Completely
   module Commands
     class Install < Base
-      help 'Install a bash completion script'
+      TARGETS = %W[
+        /usr/share/bash-completion/completions
+        /usr/local/etc/bash_completion.d
+        #{Dir.home}/.bash_completion.d
+      ]
+
+      summary 'Install a bash completion script'
+
+      help <<~HELP
+        This command will copy the specified file to one of the following directories:
+
+        #{TARGETS.map { |c| "  - #{c}" }.join "\n"}
+
+        The target filename will be the program name, and sudo will be used if necessary.
+      HELP
 
       usage 'completely install PROGRAM [SCRIPT_PATH --force]'
       usage 'completely install (-h|--help)'
@@ -32,9 +46,13 @@ module Completely
           raise "Cannot find script: m`#{script_path}`"
         end
 
-        if File.exist?(target_path) && !args['--force']
+        if target_exist? && !args['--force']
           raise "File exists: m`#{target_path}`\nUse nb`--force` to overwrite"
         end
+      end
+
+      def target_exist?
+        File.exist? target_path
       end
 
       def command
@@ -59,13 +77,8 @@ module Completely
       end
 
       def completions_path!
-        candidates = %w[
-          /usr/share/bash-completion/completions
-          /usr/local/etc/bash_completion.d
-        ]
-
-        candidates.each do |candidate|
-          return candidate if Dir.exist? candidate
+        TARGETS.each do |tarnet|
+          return tarnet if Dir.exist? tarnet
         end
 
         nil

--- a/lib/completely/commands/install.rb
+++ b/lib/completely/commands/install.rb
@@ -19,20 +19,28 @@ module Completely
         The target filename will be the program name, and sudo will be used if necessary.
       HELP
 
-      usage 'completely install PROGRAM [SCRIPT_PATH --force]'
+      usage 'completely install PROGRAM [SCRIPT_PATH --force --dry]'
       usage 'completely install (-h|--help)'
 
       option '-f --force', 'Overwrite target file if it exists'
+      option '-d --dry', 'Show the installation command but do not run it'
 
       param 'PROGRAM', 'Name of the program the completions are for.'
       param 'SCRIPT_PATH', 'Path to the source bash script [default: completely.bash].'
 
       def run
         bounce
+
+        if args['--dry']
+          puts command.join ' '
+          return
+        end
+
         success = system(*command)
         raise "Failed running command:\nnb`#{command.join ' '}`" unless success
 
         say "Saved m`#{target_path}`"
+        say 'You may need to restart your session to test it'
       end
 
     private

--- a/lib/completely/commands/install.rb
+++ b/lib/completely/commands/install.rb
@@ -1,0 +1,75 @@
+require 'completely/commands/base'
+
+module Completely
+  module Commands
+    class Install < Base
+      help 'Install a bash completion script'
+
+      usage 'completely install PROGRAM [SCRIPT_PATH --force]'
+      usage 'completely install (-h|--help)'
+
+      option '-f --force', 'Overwrite target file if it exists'
+
+      param 'PROGRAM', 'Name of the program the completions are for.'
+      param 'SCRIPT_PATH', 'Path to the source bash script [default: completely.bash].'
+
+      def run
+        bounce
+        success = system(*command)
+        raise "Failed running command:\nnb`#{command.join ' '}`" unless success
+
+        say "Saved m`#{target_path}`"
+      end
+
+    private
+
+      def bounce
+        unless completions_path
+          raise 'Cannot determine system completions directory'
+        end
+
+        unless File.exist? script_path
+          raise "Cannot find script: m`#{script_path}`"
+        end
+
+        if File.exist?(target_path) && !args['--force']
+          raise "File exists: m`#{target_path}`\nUse nb`--force` to overwrite"
+        end
+      end
+
+      def command
+        result = root? ? [] : %w[sudo]
+        result + %W[cp #{script_path} #{target_path}]
+      end
+
+      def script_path
+        args['SCRIPT_PATH'] || 'completely.bash'
+      end
+
+      def target_path
+        "#{completions_path}/#{args['PROGRAM']}"
+      end
+
+      def root?
+        Process.uid.zero?
+      end
+
+      def completions_path
+        @completions_path ||= completions_path!
+      end
+
+      def completions_path!
+        candidates = %w[
+          /usr/share/bash-completion/completions
+          /usr/local/etc/bash_completion.d
+        ]
+
+        candidates.each do |candidate|
+          return candidate if Dir.exist? candidate
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/spec/approvals/cli/commands
+++ b/spec/approvals/cli/commands
@@ -5,5 +5,6 @@ Commands:
   preview   Generate the bash completion script to STDOUT
   generate  Generate the bash completion script to a file
   test      Test completions
+  install   Install a bash completion script
 
 Run completely COMMAND --help for more information

--- a/spec/approvals/cli/install/dry
+++ b/spec/approvals/cli/install/dry
@@ -1,0 +1,1 @@
+sudo cp README.md /usr/share/bash-completion/completions/completely-test

--- a/spec/approvals/cli/install/help
+++ b/spec/approvals/cli/install/help
@@ -10,12 +10,15 @@ The target filename will be the program name, and sudo will be used if
 necessary.
 
 Usage:
-  completely install PROGRAM [SCRIPT_PATH --force]
+  completely install PROGRAM [SCRIPT_PATH --force --dry]
   completely install (-h|--help)
 
 Options:
   -f --force
     Overwrite target file if it exists
+
+  -d --dry
+    Show the installation command but do not run it
 
   -h --help
     Show this help

--- a/spec/approvals/cli/install/help
+++ b/spec/approvals/cli/install/help
@@ -1,0 +1,28 @@
+Install a bash completion script
+
+This command will copy the specified file to one of the following directories:
+
+  - /usr/share/bash-completion/completions
+  - /usr/local/etc/bash_completion.d
+  - /home/vagrant/.bash_completion.d
+
+The target filename will be the program name, and sudo will be used if
+necessary.
+
+Usage:
+  completely install PROGRAM [SCRIPT_PATH --force]
+  completely install (-h|--help)
+
+Options:
+  -f --force
+    Overwrite target file if it exists
+
+  -h --help
+    Show this help
+
+Parameters:
+  PROGRAM
+    Name of the program the completions are for.
+
+  SCRIPT_PATH
+    Path to the source bash script [default: completely.bash].

--- a/spec/approvals/cli/install/install-default
+++ b/spec/approvals/cli/install/install-default
@@ -1,1 +1,2 @@
 Saved /usr/share/bash-completion/completions/completely-test
+You may need to restart your session to test it

--- a/spec/approvals/cli/install/install-default
+++ b/spec/approvals/cli/install/install-default
@@ -1,0 +1,1 @@
+Saved /usr/share/bash-completion/completions/completely-test

--- a/spec/approvals/cli/install/install-specified
+++ b/spec/approvals/cli/install/install-specified
@@ -1,1 +1,2 @@
 Saved /usr/share/bash-completion/completions/completely-test
+You may need to restart your session to test it

--- a/spec/approvals/cli/install/install-specified
+++ b/spec/approvals/cli/install/install-specified
@@ -1,0 +1,1 @@
+Saved /usr/share/bash-completion/completions/completely-test

--- a/spec/approvals/cli/install/missing-script
+++ b/spec/approvals/cli/install/missing-script
@@ -1,0 +1,1 @@
+#<RuntimeError: Cannot find script: m`completely.bash`>

--- a/spec/approvals/cli/install/no-args
+++ b/spec/approvals/cli/install/no-args
@@ -1,0 +1,3 @@
+Usage:
+  completely install PROGRAM [SCRIPT_PATH --force]
+  completely install (-h|--help)

--- a/spec/approvals/cli/install/no-args
+++ b/spec/approvals/cli/install/no-args
@@ -1,3 +1,3 @@
 Usage:
-  completely install PROGRAM [SCRIPT_PATH --force]
+  completely install PROGRAM [SCRIPT_PATH --force --dry]
   completely install (-h|--help)

--- a/spec/approvals/cli/install/no-completion-targets
+++ b/spec/approvals/cli/install/no-completion-targets
@@ -1,0 +1,1 @@
+#<RuntimeError: Cannot determine system completions directory>

--- a/spec/approvals/cli/install/target-exists
+++ b/spec/approvals/cli/install/target-exists
@@ -1,0 +1,2 @@
+#<RuntimeError: File exists: m`/usr/share/bash-completion/completions/completely-test`
+Use nb`--force` to overwrite>

--- a/spec/completely/commands/install_spec.rb
+++ b/spec/completely/commands/install_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe Commands::Install do
+  subject { described_class.new }
+
+  context 'with --help' do
+    it 'shows long usage' do
+      expect { subject.execute %w[install --help] }.to output_approval('cli/install/help')
+    end
+  end
+
+  context 'without arguments' do
+    it 'shows short usage' do
+      expect { subject.execute %w[install] }.to output_approval('cli/install/no-args')
+    end
+  end
+
+  context 'with only the program name argument' do
+    context 'when the default script is not found' do
+      it 'raises an error' do
+        expect { subject.execute %w[install completely-test] }.to raise_approval('cli/install/missing-script')
+      end
+    end
+
+    context 'when the default script is found' do
+      let(:expected_args) {
+        %w[
+          sudo
+          cp
+          completely.bash
+          /usr/share/bash-completion/completions/completely-test
+        ]
+      }
+
+      before do
+        reset_tmp_dir
+        File.write 'spec/tmp/completely.bash', 'not-important'
+      end
+
+      it 'copies the script' do
+        Dir.chdir 'spec/tmp' do
+          expect(subject).to receive(:system).with(*expected_args).and_return true
+          expect { subject.execute %W[install completely-test] }.to output_approval('cli/install/install-default')
+        end
+      end
+    end
+  end
+
+  context 'with the program name argument and a script argument' do
+    let(:expected_args) {
+      %w[
+        sudo
+        cp
+        README.md
+        /usr/share/bash-completion/completions/completely-test
+      ]
+    }
+
+    it 'copies the script' do
+      expect(subject).to receive(:system).with(*expected_args).and_return true
+      expect { subject.execute %W[install completely-test README.md] }.to output_approval('cli/install/install-specified')
+    end
+  end
+
+  context 'when none of the target directories is found' do
+    it 'raises an error' do
+      expect(subject).to receive(:completions_path).and_return nil
+      expect { subject.execute %W[install completely-test README.md] }.to raise_approval('cli/install/no-completion-targets')
+    end
+  end
+
+  context 'when the target file exists' do
+    it 'raises an error' do
+      expect(subject).to receive(:target_exist?).and_return true
+      expect { subject.execute %W[install completely-test README.md] }.to raise_approval('cli/install/target-exists')
+    end
+  end
+end

--- a/spec/completely/commands/install_spec.rb
+++ b/spec/completely/commands/install_spec.rb
@@ -21,7 +21,7 @@ describe Commands::Install do
     context 'when the default script is not found' do
       it 'raises an error' do
         expect { subject.execute %w[install completely-test] }
-          .to raise_approval('cli/install/missing-script')
+          .to raise_approval('cli/install/missing-script').diff(8)
       end
     end
 
@@ -78,7 +78,7 @@ describe Commands::Install do
     it 'raises an error' do
       allow(subject).to receive(:completions_path).and_return nil
       expect { subject.execute %w[install completely-test README.md] }
-        .to raise_approval('cli/install/no-completion-targets')
+        .to raise_approval('cli/install/no-completion-targets').diff(8)
     end
   end
 
@@ -86,7 +86,7 @@ describe Commands::Install do
     it 'raises an error' do
       allow(subject).to receive(:target_exist?).and_return true
       expect { subject.execute %w[install completely-test README.md] }
-        .to raise_approval('cli/install/target-exists')
+        .to raise_approval('cli/install/target-exists').diff(8)
     end
   end
 end

--- a/spec/completely/commands/install_spec.rb
+++ b/spec/completely/commands/install_spec.rb
@@ -5,32 +5,35 @@ describe Commands::Install do
 
   context 'with --help' do
     it 'shows long usage' do
-      expect { subject.execute %w[install --help] }.to output_approval('cli/install/help').diff(10)
+      expect { subject.execute %w[install --help] }
+        .to output_approval('cli/install/help').diff(10)
     end
   end
 
   context 'without arguments' do
     it 'shows short usage' do
-      expect { subject.execute %w[install] }.to output_approval('cli/install/no-args')
+      expect { subject.execute %w[install] }
+        .to output_approval('cli/install/no-args')
     end
   end
 
   context 'with only the program name argument' do
     context 'when the default script is not found' do
       it 'raises an error' do
-        expect { subject.execute %w[install completely-test] }.to raise_approval('cli/install/missing-script')
+        expect { subject.execute %w[install completely-test] }
+          .to raise_approval('cli/install/missing-script')
       end
     end
 
     context 'when the default script is found' do
-      let(:expected_args) {
+      let(:expected_args) do
         %w[
           sudo
           cp
           completely.bash
           /usr/share/bash-completion/completions/completely-test
         ]
-      }
+      end
 
       before do
         reset_tmp_dir
@@ -39,40 +42,51 @@ describe Commands::Install do
 
       it 'copies the script' do
         Dir.chdir 'spec/tmp' do
-          expect(subject).to receive(:system).with(*expected_args).and_return true
-          expect { subject.execute %W[install completely-test] }.to output_approval('cli/install/install-default')
+          allow(subject).to receive(:system).with(*expected_args).and_return true
+          expect { subject.execute %w[install completely-test] }
+            .to output_approval('cli/install/install-default')
         end
       end
     end
   end
 
   context 'with the program name argument and a script argument' do
-    let(:expected_args) {
+    let(:expected_args) do
       %w[
         sudo
         cp
         README.md
         /usr/share/bash-completion/completions/completely-test
       ]
-    }
+    end
 
     it 'copies the script' do
-      expect(subject).to receive(:system).with(*expected_args).and_return true
-      expect { subject.execute %W[install completely-test README.md] }.to output_approval('cli/install/install-specified')
+      allow(subject).to receive(:system).with(*expected_args).and_return true
+      expect { subject.execute %w[install completely-test README.md] }
+        .to output_approval('cli/install/install-specified')
+    end
+  end
+
+  context 'with --dry' do
+    it 'shows the command' do
+      expect { subject.execute %w[install completely-test README.md --dry] }
+        .to output_approval('cli/install/dry')
     end
   end
 
   context 'when none of the target directories is found' do
     it 'raises an error' do
-      expect(subject).to receive(:completions_path).and_return nil
-      expect { subject.execute %W[install completely-test README.md] }.to raise_approval('cli/install/no-completion-targets')
+      allow(subject).to receive(:completions_path).and_return nil
+      expect { subject.execute %w[install completely-test README.md] }
+        .to raise_approval('cli/install/no-completion-targets')
     end
   end
 
   context 'when the target file exists' do
     it 'raises an error' do
-      expect(subject).to receive(:target_exist?).and_return true
-      expect { subject.execute %W[install completely-test README.md] }.to raise_approval('cli/install/target-exists')
+      allow(subject).to receive(:target_exist?).and_return true
+      expect { subject.execute %w[install completely-test README.md] }
+        .to raise_approval('cli/install/target-exists')
     end
   end
 end

--- a/spec/completely/commands/install_spec.rb
+++ b/spec/completely/commands/install_spec.rb
@@ -5,7 +5,7 @@ describe Commands::Install do
 
   context 'with --help' do
     it 'shows long usage' do
-      expect { subject.execute %w[install --help] }.to output_approval('cli/install/help')
+      expect { subject.execute %w[install --help] }.to output_approval('cli/install/help').diff(10)
     end
   end
 


### PR DESCRIPTION
Closes #18 

Tasks

- [x] Initial implementation
- [x] Specs
- [x] Add `--dry` to just show the installation command instead of running it
