### PR TITLE
Add `~/.local/share/bash-completion/completions` to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Alternatively, you can copy the script manually to one of these directories
 
 - `/usr/share/bash-completion/completions`
 - `/usr/local/etc/bash_completion.d`
+- `~/.local/share/bash-completion/completions`
 
 ## Testing and debugging completion scripts
 


### PR DESCRIPTION
`~/.local/share/bash-completion/completions` is the XDG directory for bash completions installed by the user.