### PR TITLE
Change whitespace, indentation or line-breaks

### DIFF
--- a/lib/completely/templates/template.erb
+++ b/lib/completely/templates/template.erb
@@ -11,7 +11,7 @@
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/cli/generated-script
+++ b/spec/approvals/cli/generated-script
@@ -11,7 +11,7 @@ _mygit_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/cli/generated-script-alt
+++ b/spec/approvals/cli/generated-script-alt
@@ -11,7 +11,7 @@ _mycomps_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/cli/generated-wrapped-script
+++ b/spec/approvals/cli/generated-wrapped-script
@@ -12,7 +12,7 @@ give_comps() {
   echo $''
   echo $'  if [[ "${cur:0:1}" == "-" ]]; then'
   echo $'    echo "$words"'
-  echo $'  '
+  echo $''
   echo $'  else'
   echo $'    for word in $words; do'
   echo $'      [[ "${word:0:1}" != "-" ]] && result+=("$word")'

--- a/spec/approvals/cli/test/completely-tester-1.sh
+++ b/spec/approvals/cli/test/completely-tester-1.sh
@@ -19,7 +19,7 @@ _mygit_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/cli/test/completely-tester-2.sh
+++ b/spec/approvals/cli/test/completely-tester-2.sh
@@ -19,7 +19,7 @@ _mygit_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/cli/test/completely-tester.sh
+++ b/spec/approvals/cli/test/completely-tester.sh
@@ -19,7 +19,7 @@ _mygit_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/completions/function
+++ b/spec/approvals/completions/function
@@ -12,7 +12,7 @@ send_completions() {
   echo $''
   echo $'  if [[ "${cur:0:1}" == "-" ]]; then'
   echo $'    echo "$words"'
-  echo $'  '
+  echo $''
   echo $'  else'
   echo $'    for word in $words; do'
   echo $'      [[ "${word:0:1}" != "-" ]] && result+=("$word")'

--- a/spec/approvals/completions/script
+++ b/spec/approvals/completions/script
@@ -11,7 +11,7 @@ _completely_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/completions/script-only-spaces
+++ b/spec/approvals/completions/script-only-spaces
@@ -11,7 +11,7 @@ _completely_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/approvals/completions/script-with-debug
+++ b/spec/approvals/completions/script-with-debug
@@ -11,7 +11,7 @@ _completely_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")

--- a/spec/fixtures/tester/default.bash
+++ b/spec/fixtures/tester/default.bash
@@ -11,7 +11,7 @@ _cli_completions_filter() {
 
   if [[ "${cur:0:1}" == "-" ]]; then
     echo "$words"
-  
+
   else
     for word in $words; do
       [[ "${word:0:1}" != "-" ]] && result+=("$word")


### PR DESCRIPTION
I noticed a little trailing whitespace in the template. As this lands in every generated completion-script, I wanted to remove it at the source. Otherwise, it might lead to unneeded churn (when tooling removes it, but it gets added again), error-highlighting (linting, pre-commit-hooks, et al) and disk-space usage (depends on how many completetion you generate, of course).

This is a really unimportant change, yet I took the time to open this PR. So maybe there is even some emotional value in the ensuing calmness coming from fewer unneeded spaces copied into generated files?