### PR TITLE
Update instructions and template for obtaining list of git branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mygit status:
 - --help
 - --verbose
 - --branch
-- $(git branch 2>/dev/null)
+- $(git branch --format='%(refname:short)' 2>/dev/null)
 
 mygit init:
 - --bare
@@ -169,7 +169,7 @@ branches to your suggestions, use the following:
 
 ```yaml
 mygit:
-- $(git branch 2>/dev/null)
+- $(git branch --format='%(refname:short)' 2>/dev/null)
 ```
 
 The `2> /dev/null` is used so that if the command is executed in a directory
@@ -186,10 +186,10 @@ mygit checkout:
 - -b
 
 mygit checkout*--branch:
-- $(git branch 2>/dev/null)
+- $(git branch --format='%(refname:short)' 2>/dev/null)
 
 mygit checkout*-b:
-- $(git branch 2>/dev/null)
+- $(git branch --format='%(refname:short)' 2>/dev/null)
 ```
 
 The above will suggest git branches for commands that end with `-b` or `--branch`.
@@ -202,7 +202,7 @@ mygit checkout:
 - -b
 
 mygit checkout*--branch: &branches
-- $(git branch 2>/dev/null)
+- $(git branch --format='%(refname:short)' 2>/dev/null)
 
 mygit checkout*-b: *branches
 ```

--- a/lib/completely/templates/sample.yaml
+++ b/lib/completely/templates/sample.yaml
@@ -9,7 +9,7 @@ mygit status:
 - --help
 - --verbose
 - --branch
-- $(git branch 2>/dev/null)
+- $(git branch --format='%(refname:short)' 2>/dev/null)
 
 mygit init:
 - --bare

--- a/spec/approvals/cli/generated-script
+++ b/spec/approvals/cli/generated-script
@@ -29,7 +29,7 @@ _mygit_completions() {
 
   case "$compline" in
     'status'*)
-      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch 2>/dev/null)")" -- "$cur")
+      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch --format='%(refname:short)' 2>/dev/null)")" -- "$cur")
       ;;
 
     'commit'*)

--- a/spec/approvals/cli/generated-script-alt
+++ b/spec/approvals/cli/generated-script-alt
@@ -29,7 +29,7 @@ _mycomps() {
 
   case "$compline" in
     'status'*)
-      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mycomps_filter "--help --verbose --branch $(git branch 2>/dev/null)")" -- "$cur")
+      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mycomps_filter "--help --verbose --branch $(git branch --format='%(refname:short)' 2>/dev/null)")" -- "$cur")
       ;;
 
     'commit'*)

--- a/spec/approvals/cli/generated-wrapped-script
+++ b/spec/approvals/cli/generated-wrapped-script
@@ -30,7 +30,7 @@ give_comps() {
   echo $''
   echo $'  case "$compline" in'
   echo $'    \'status\'*)'
-  echo $'      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch 2>/dev/null)")" -- "$cur")'
+  echo $'      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch --format=\'%(refname:short)\' 2>/dev/null)")" -- "$cur")'
   echo $'      ;;'
   echo $''
   echo $'    \'commit\'*)'

--- a/spec/approvals/cli/test/completely-tester-1.sh
+++ b/spec/approvals/cli/test/completely-tester-1.sh
@@ -37,7 +37,7 @@ _mygit_completions() {
 
   case "$compline" in
     'status'*)
-      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch 2>/dev/null)")" -- "$cur")
+      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch --format='%(refname:short)' 2>/dev/null)")" -- "$cur")
       ;;
 
     'commit'*)

--- a/spec/approvals/cli/test/completely-tester-2.sh
+++ b/spec/approvals/cli/test/completely-tester-2.sh
@@ -37,7 +37,7 @@ _mygit_completions() {
 
   case "$compline" in
     'status'*)
-      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch 2>/dev/null)")" -- "$cur")
+      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch --format='%(refname:short)' 2>/dev/null)")" -- "$cur")
       ;;
 
     'commit'*)

--- a/spec/approvals/cli/test/completely-tester.sh
+++ b/spec/approvals/cli/test/completely-tester.sh
@@ -37,7 +37,7 @@ _mygit_completions() {
 
   case "$compline" in
     'status'*)
-      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch 2>/dev/null)")" -- "$cur")
+      while read -r; do COMPREPLY+=("$REPLY"); done < <(compgen -W "$(_mygit_completions_filter "--help --verbose --branch $(git branch --format='%(refname:short)' 2>/dev/null)")" -- "$cur")
       ;;
 
     'commit'*)


### PR DESCRIPTION
Update the `git branch` example from:

```bash
- "$(git branch 2>/dev/null)"
```

to

```bash
- "$(git branch --format='%(refname:short)' 2>/dev/null)"
```

in order to remove the asterisk from `* master`, which meant "complete files also".
